### PR TITLE
Add option to disable the shadow hook to be able to use NVR with vanilla shadows.

### DIFF
--- a/NewVegasReloaded/Main.cpp
+++ b/NewVegasReloaded/Main.cpp
@@ -40,7 +40,7 @@ extern "C" {
 			CreateRenderHook();
 			CreateFormLoadHook();
 			CreateSettingsHook();
-			CreateShadowsHook();
+			if (TheSettingManager->SettingsMain.Main.ShadowManagement) CreateShadowsHook();
 			if (TheSettingManager->SettingsMain.Main.MemoryManagement) CreateMemoryManagementHook();
 			if (TheSettingManager->SettingsMain.CameraMode.Enabled) CreateCameraModeHook();
 			if (TheSettingManager->SettingsMain.SleepingMode.Enabled) CreateSleepingModeHook();

--- a/OblivionReloaded/Main.cpp
+++ b/OblivionReloaded/Main.cpp
@@ -45,7 +45,7 @@ extern "C" {
 			CreateFormLoadHook();
 			CreateSettingsHook();
 			CreateScriptHook();
-			CreateShadowsHook();
+			if (TheSettingManager->SettingsMain.Main.ShadowManagement) CreateShadowsHook();
 			CreateWeatherModeHook();
 			CreateAnimationHook();
 			if (TheSettingManager->SettingsMain.Main.MemoryManagement) CreateMemoryManagementHook();

--- a/TESReloaded/Core/SettingManager.cpp
+++ b/TESReloaded/Core/SettingManager.cpp
@@ -84,6 +84,7 @@ SettingManager::SettingManager() {
 	SettingsMain.Main.RemoveUnderwater = GetPrivateProfileIntA("Main", "RemoveUnderwater", 1, Filename);
 	SettingsMain.Main.RemovePrecipitations = GetPrivateProfileIntA("Main", "RemovePrecipitations", 0, Filename);
 	SettingsMain.Main.MemoryManagement = GetPrivateProfileIntA("Main", "MemoryManagement", 0, Filename);
+	SettingsMain.Main.ShadowManagement = GetPrivateProfileIntA("Main", "ShadowManagement", 1, Filename);
 	SettingsMain.Main.AnisotropicFilter = GetPrivateProfileIntA("Main", "AnisotropicFilter", 0, Filename);
 	GetPrivateProfileStringA("Main", "FarPlaneDistance", "0.0", value, SettingStringBuffer, Filename);
 	SettingsMain.Main.FarPlaneDistance = atof(value);

--- a/TESReloaded/Core/SettingManager.h
+++ b/TESReloaded/Core/SettingManager.h
@@ -82,6 +82,7 @@ struct SettingsMainStruct {
 		bool	RemoveUnderwater;
 		bool	RemovePrecipitations;
 		bool	MemoryManagement;
+		bool	ShadowManagement;
 		bool	FPSOverlay;
 		bool	SaveSettings;
 		bool	ReplaceIntro;


### PR DESCRIPTION
For some people, the Reloaded shadows are an incredibly costly performance hog (this is especially true when using a weaker GPU), and detrimental to the experience with Reloaded.
Unfortunately, due to the way the hook is set up, it is not possible to use Reloaded with the vanilla shadows at the moment.
This PR introduces an option to disable the hook entirely on game start, not exposed on the menu by default, and only able to be toggled through the config file.
Added the check to the OblivionReloaded project too for the sake of consistency.